### PR TITLE
Add 'update_timeout' for updating in-memory database

### DIFF
--- a/ovsdbapp/backend/ovs_idl/__init__.py
+++ b/ovsdbapp/backend/ovs_idl/__init__.py
@@ -27,6 +27,7 @@ class Backend(object):
     _ovsdb_connection = None
 
     def __init__(self, connection, start=True, auto_index=True, **kwargs):
+        self.update_timeout = kwargs.pop("update_timeout", None)
         super().__init__(**kwargs)
         self.ovsdb_connection = connection
         if auto_index:


### PR DESCRIPTION
Provide ability to set timeout for updating in-memory database after a successful transaction.

Change-Id: Iec4bceba42fe3addbe439a522a005416912c84a4