### PR TITLE
nb: add support for mirror-rules in mirrors

### DIFF
--- a/ovsdbapp/constants.py
+++ b/ovsdbapp/constants.py
@@ -46,3 +46,11 @@ MAIN_ROUTE_TABLE = ""
 
 LOCALNET = 'localnet'
 DEFAULT_CHAIN = ''
+
+MIRROR_TYPE_GRE = 'gre'
+MIRROR_TYPE_ERSPAN = 'erspan'
+MIRROR_TYPE_LOCAL = 'local'
+MIRROR_TYPE_LPORT = 'lport'
+
+MIRROR_RULE_SKIP = 'skip'
+MIRROR_RULE_MIRROR = 'mirror'

--- a/ovsdbapp/schema/ovn_northbound/api.py
+++ b/ovsdbapp/schema/ovn_northbound/api.py
@@ -1486,11 +1486,21 @@ class API(api.API, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def mirror_get(self, uuid):
-        """Get the Mirror entry"""
+        """Get the Mirror entry
+
+        :param uuid:   The name or uuid of the mirror
+        :type uuid:    string or uuid.UUID
+        :returns:      :class:`Command` with RowView result
+        """
 
     @abc.abstractmethod
     def mirror_del(self, mirror):
-        """Delete a Mirror"""
+        """Delete a Mirror
+
+        :param mirror:   The uuid of the mirror
+        :type mirror:    uuid.UUID
+        :returns:        :class:`Command` with no result
+        """
 
     @abc.abstractmethod
     def mirror_add(self, name, mirror_type, index, direction_filter, dest,
@@ -1500,7 +1510,8 @@ class API(api.API, metaclass=abc.ABCMeta):
 
         :param name:    Name of the Mirror to create.
         :type name:     str
-        :param mirror_type:    The type of the mirroring can be gre or erspan.
+        :param mirror_type:    The type of the mirroring can be gre, erspan,
+                               local, lport.
         :type mirror_type:     str
         :param index:   The index filed will be used for the Index field in
                         ERSPAN header as decimal, and as hexadecimal value in
@@ -1508,9 +1519,11 @@ class API(api.API, metaclass=abc.ABCMeta):
                         field.
         :type index:    int
         :param direction_filter:  The direction of the traffic to be mirrored,
-                                  can be from-lport and to-lprt.
+                                  can be from-lport, to-lport or both.
         :type direction_filter:   str
-        :param dest:    The destination IP address of the mirroring.
+        :param dest:    The destination IP address of the mirroring
+                        (gre,erspan), name of the logical port (lport),
+                        OVS interface (local).
         :type dest:     str
 
 
@@ -1522,6 +1535,43 @@ class API(api.API, metaclass=abc.ABCMeta):
                              sink pair already exists.
         :type may_exist:     Optional[bool]
         :returns:            :class:`Command` with RowView result
+        """
+
+    @abc.abstractmethod
+    def mirror_rule_add(self, mirror, priority, match, action,
+                        may_exist=False):
+        """Add a mirror rule selection to given 'lport' mirror.
+
+        :param mirror:    The name or uuid of the mirror.
+        :type mirror:     string or uuid.UUID
+        :param priority:  The priority of the rule.
+        :type priority:   int
+        :param match:     The match for selecting mirrored traffic.
+        :type match:      string
+        :param action:    The rule action can be 'mirror' or 'skip'
+        :type action:     string
+        :param may_exist: If True, update any existing Mirror rule entry
+                          if it already exists.  Default is False which will
+                          raise an error if a Mirror rule entry with same
+                          priority, match pair already exists.
+        :type may_exist:  Optional[bool]
+        :returns:         :class:`Command` with RowView result
+        """
+
+    @abc.abstractmethod
+    def mirror_rule_del(self, mirror, priority=None, match=None,
+                        if_exists=False):
+        """Delete a mirror rule on a mirror.
+
+        :param mirror:    The name or uuid of the mirror.
+        :type mirror:     string or uuid.UUID
+        :param priority:  The priority of the rule.
+        :type priority:   int
+        :param match:     The match for selecting mirrored traffic.
+        :type match:      string
+        :param if_exists: If True, don't fail if the mirror rule doesn't exist
+        :type if_exists:  boolean
+        :returns:         :class:`Command` with RowView result
         """
 
     @abc.abstractmethod

--- a/ovsdbapp/schema/ovn_northbound/impl_idl.py
+++ b/ovsdbapp/schema/ovn_northbound/impl_idl.py
@@ -438,8 +438,8 @@ class OvnNbApiIdlImpl(ovs_idl.Backend, api.API):
     def bfd_get(self, uuid):
         return cmd.BFDGetCommand(self, uuid)
 
-    def mirror_get(self, uuid):
-        return cmd.MirrorGetCommand(self, uuid)
+    def mirror_get(self, mirror):
+        return cmd.MirrorGetCommand(self, mirror)
 
     def mirror_del(self, mirror):
         return cmd.MirrorDelCommand(self, mirror)
@@ -453,6 +453,16 @@ class OvnNbApiIdlImpl(ovs_idl.Backend, api.API):
                                     dest=dest,
                                     external_ids=external_ids,
                                     may_exist=may_exist)
+
+    def mirror_rule_add(self, mirror, priority, match, action,
+                        may_exist=False):
+        return cmd.MirrorRuleAddCommand(self, mirror, priority, match,
+                                        action, may_exist=may_exist)
+
+    def mirror_rule_del(self, mirror, priority=None, match=None,
+                        if_exists=False):
+        return cmd.MirrorRuleDelCommand(self, mirror, priority=priority,
+                                        match=match, if_exists=if_exists)
 
     def lsp_attach_mirror(self, port, mirror, may_exist=False):
         return cmd.LspAttachMirror(self, port, mirror, may_exist)

--- a/ovsdbapp/tests/functional/schema/ovn_northbound/test_impl_idl.py
+++ b/ovsdbapp/tests/functional/schema/ovn_northbound/test_impl_idl.py
@@ -2789,7 +2789,8 @@ class TestMirrorOps(OvnNorthboundTest):
         self.port_uuid = lsp_add_cmd.result.uuid
 
     def _mirror_add(self, name=None, direction_filter='to-lport',
-                    dest='10.11.1.1', mirror_type='gre', index=42, **kwargs):
+                    dest='10.11.1.1', mirror_type=const.MIRROR_TYPE_GRE,
+                    index=42, **kwargs):
         if not name:
             name = utils.get_rand_name()
         cmd = self.api.mirror_add(name, mirror_type, index, direction_filter,
@@ -2807,8 +2808,8 @@ class TestMirrorOps(OvnNorthboundTest):
 
     def test_mirror_add_duplicate(self):
         name = utils.get_rand_name()
-        cmd = self.api.mirror_add(name, 'gre', 100, 'from-lport',
-                                  '192.169.1.1')
+        cmd = self.api.mirror_add(name, const.MIRROR_TYPE_GRE, 100,
+                                  'from-lport', '192.169.1.1')
         cmd.execute(check_error=True)
         self.assertRaises(RuntimeError, cmd.execute, check_error=True)
 
@@ -2824,7 +2825,7 @@ class TestMirrorOps(OvnNorthboundTest):
         mirror1 = self._mirror_add(name=name, dest='10.12.1.0')
         mirror2 = self._mirror_add(
             name=name, direction_filter='from-lport', dest='10.12.1.0',
-            mirror_type='gre', index=100, may_exist=True,
+            mirror_type=const.MIRROR_TYPE_GRE, index=100, may_exist=True,
         )
         self.assertNotEqual(mirror1, mirror2)
         self.assertEqual(mirror1.uuid, mirror2.uuid)
@@ -2838,7 +2839,8 @@ class TestMirrorOps(OvnNorthboundTest):
 
     def test_mirror_get(self):
         name = utils.get_rand_name()
-        mirror1 = self.api.mirror_add(name, 'gre', 100, 'from-lport',
+        mirror1 = self.api.mirror_add(name, const.MIRROR_TYPE_GRE, 100,
+                                      'from-lport',
                                       '10.15.1.1').execute(check_error=True)
         mirror2 = self.api.mirror_get(mirror1.uuid).execute(check_error=True)
         self.assertEqual(mirror1, mirror2)
@@ -2907,3 +2909,107 @@ class TestMirrorOps(OvnNorthboundTest):
             if_exist=True).execute(check_error=True)
         self.assertEqual(1, len(port.mirror_rules))
         self.assertEqual(mirror1.uuid, port.mirror_rules[0].uuid)
+
+    def _mirror_rule_add(self, mirror, priority=1, match='1',
+                         action=const.MIRROR_RULE_MIRROR, **kwargs):
+        rule = self.api.mirror_rule_add(
+            mirror.uuid, priority, match, action, **kwargs).execute(
+            check_error=True)
+        self.assertIn(rule, mirror.mirror_rules)
+        self.assertEqual(priority, rule.priority)
+        self.assertEqual(match, rule.match)
+        self.assertEqual(action, rule.action)
+        return rule
+
+    def test_mirror_rule_add(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        rule = self._mirror_rule_add(mirror)
+        self.assertEqual(mirror.mirror_rules, [rule])
+
+    def test_mirror_rule_add_no_lport_type(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LOCAL, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        cmd = self.api.mirror_rule_add(mirror.uuid, 1, '1',
+                                       const.MIRROR_RULE_MIRROR)
+        self.assertRaises(RuntimeError, cmd.execute, check_error=True)
+
+    def test_mirror_rule_add_invalid_action(self):
+        self.assertRaises(TypeError, self.api.mirror_rule_add, 'testmirror',
+                          1, '1', 'invalid-action')
+
+    def test_mirror_rule_add_duplicate(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        cmd = self.api.mirror_rule_add(mirror.uuid, 1, '1',
+                                       const.MIRROR_RULE_MIRROR)
+        rule = cmd.execute(check_error=True)
+        self.assertRaises(RuntimeError, cmd.execute, check_error=True)
+        self.assertEqual(mirror.mirror_rules, [rule])
+
+    def test_mirror_rule_add_may_exist_no_change(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        rule1 = self._mirror_rule_add(mirror)
+        rule2 = self._mirror_rule_add(mirror, may_exist=True)
+        self.assertEqual(rule1, rule2)
+        self.assertEqual(mirror.mirror_rules, [rule1])
+
+    def test_mirror_rule_del_match_no_prio(self):
+        self.assertRaises(ValueError, self.api.mirror_rule_del,
+                          'testmirror', priority=None, match='1')
+
+    def test_mirror_rule_del_no_exist(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        cmd = self.api.mirror_rule_del(mirror.uuid, priority=200)
+        self.assertRaises(RuntimeError, cmd.execute, check_error=True)
+
+    def test_mirror_rule_del_if_exist(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        self.api.mirror_rule_del(mirror.uuid, priority=200,
+                                 if_exists=True).execute(check_error=True)
+
+    def test_mirror_rule_del_all(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        rules = []
+        for prio in range(1, 4):
+            rules.append(self._mirror_rule_add(mirror, priority=prio))
+        for rule in rules:
+            self.assertIn(rule, mirror.mirror_rules)
+        self.api.mirror_rule_del(mirror.uuid).execute(check_error=True)
+        self.assertEqual(mirror.mirror_rules, [])
+
+    def test_mirror_rule_del_by_prio(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        rule1 = self._mirror_rule_add(mirror,)
+        rule2 = self._mirror_rule_add(mirror, match='ip4')
+        rule3 = self._mirror_rule_add(mirror, priority=2)
+        for rule in [rule1, rule2, rule3]:
+            self.assertIn(rule, mirror.mirror_rules)
+        self.api.mirror_rule_del(mirror.uuid, rule1.priority).execute(
+            check_error=True)
+        self.assertEqual(mirror.mirror_rules, [rule3])
+
+    def test_mirror_rule_del_by_prio_match(self):
+        mirror = self.api.mirror_add(utils.get_rand_name(),
+                                     const.MIRROR_TYPE_LPORT, 0, 'both',
+                                     self.port_uuid).execute(check_error=True)
+        rule1 = self._mirror_rule_add(mirror)
+        rule2 = self._mirror_rule_add(mirror, match='ip4')
+        for rule in [rule1, rule2]:
+            self.assertIn(rule, mirror.mirror_rules)
+        self.api.mirror_rule_del(mirror.uuid, rule1.priority,
+                                 rule1.match).execute(check_error=True)
+        self.assertEqual(mirror.mirror_rules, [rule2])

--- a/python-ovsdbapp.spec
+++ b/python-ovsdbapp.spec
@@ -20,7 +20,7 @@ This package contains Python OVSDB Application Library test files.
 
 Name:       python-%{library}
 Version:    2.5.0
-Release:    1.ROCKIT4@BUILDID@%{?dist}
+Release:    1.ROCKIT5@BUILDID@%{?dist}
 Summary:    Python OVSDB Application Library
 License:    ASL 2.0
 URL:        http://launchpad.net/%{library}/

--- a/releasenotes/notes/ovn-mirror-rules-support-56a36a90c1fcaab3.yaml
+++ b/releasenotes/notes/ovn-mirror-rules-support-56a36a90c1fcaab3.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Support mirror rules and new mirror type 'lport'.
+    It was added in https://github.com/ovn-org/ovn/commit/3dd8f36b85b3e648bc506839aa62e81b21c41e30


### PR DESCRIPTION
OVN has added new Mirror type - 'lport' and new entities - mirror rules This change adds support for this feature.

Changes include:
1. MirrorAddCommand - to support new mirror type
2. LspAttachMirror - to fix addition of mirror to LSP
3. LspDetachMirror - to fix deletion of mirror from LSP
4. MirrorRuleAddCommand - to create mirror rules
5. MirrorRuleDelCommand - to delete mirror rules

See this commit for more information:
https://github.com/ovn-org/ovn/commit/3dd8f36b85b3e648bc506839aa62e81b21c41e30

Closes-Bug: #2111518

Change-Id: I56439ff1f4c19d5a015ac9d9cbaccf7a7922377a